### PR TITLE
chore: publish typings and add repository link on the npm page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # meta-png
-[![NPM version](https://badge.fury.io/js/meta-png.svg)](https://badge.fury.io/js/meta-png.svg)
+[![NPM version](https://badge.fury.io/js/meta-png.svg)](https://www.npmjs.com/package/meta-png)
 [![codecov](https://codecov.io/gh/lucach/meta-png/branch/main/graph/badge.svg?token=ZGEFAO5WDP)](https://codecov.io/gh/lucach/meta-png)
 ![Test](https://github.com/lucach/meta-png/workflows/Test/badge.svg)
 ![Lint](https://github.com/lucach/meta-png/workflows/Lint/badge.svg)

--- a/package.json
+++ b/package.json
@@ -4,8 +4,10 @@
   "description": "Write and read metadata in PNG files.",
   "main": "dist/meta-png.umd.js",
   "files": [
-    "dist"
+    "dist",
+    "types/main.d.ts"
   ],
+  "repository": "https://github.com/lucach/meta-png.git",
   "scripts": {
     "test": "jest",
     "test:coverage": "npm run test -- --ci --coverage",


### PR DESCRIPTION
Hey,

First of all - thanks for this package!
I've seen that the typings file is not being published - because of that the typings remain invisible for potential users of this library :( So, I've added the typings file to the published package - now this issue should be fixed.
Also, I've added a repository link, so NPM can nicely point to this repo (currently there is no way of finding this repo from NPM page). Lastly, I've linked npm badge to point to the [NPM page of this package](https://www.npmjs.com/package/meta-png).

So, after these changes it should be easy for the end users to be redirected between npm page & github repo 🎉 