### PR TITLE
fix: isPNG fails on some files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "meta-png",
       "version": "1.0.3",
       "license": "ISC",
+      "dependencies": {
+        "is-png": "^2.0.0"
+      },
       "devDependencies": {
         "@babel/core": "^7.12.13",
         "@babel/preset-env": "^7.12.13",
@@ -7103,6 +7106,14 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-png": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-png/-/is-png-2.0.0.tgz",
+      "integrity": "sha512-4KPGizaVGj2LK7xwJIz8o5B2ubu1D/vcQsgOGFEDlpcvgZHto4gBnyd0ig7Ws+67ixmwKoNmu0hYnpo6AaKb5g==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -19078,6 +19089,11 @@
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
       "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
       "dev": true
+    },
+    "is-png": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-png/-/is-png-2.0.0.tgz",
+      "integrity": "sha512-4KPGizaVGj2LK7xwJIz8o5B2ubu1D/vcQsgOGFEDlpcvgZHto4gBnyd0ig7Ws+67ixmwKoNmu0hYnpo6AaKb5g=="
     },
     "is-potential-custom-element-name": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -43,5 +43,8 @@
     "rollup": "^2.39.0",
     "rollup-plugin-terser": "^7.0.2",
     "typescript": "^4.7.4"
+  },
+  "dependencies": {
+    "is-png": "^2.0.0"
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -1,3 +1,5 @@
+const isPNG = require('is-png');
+
 /**
  * Packs a number into a 4 bytes Uint8Array, treating it as uint32.
  *
@@ -53,18 +55,6 @@ function concatArrays(arrays) {
     lenSoFar += arrays[i].byteLength;
   }
   return finalArray;
-}
-
-/**
- * Checks whether a given array has a valid PNG header.
- *
- * @param {Uint8Array} array - The array to check.
- * @returns {boolean} - true if array has a valid PNG header, false otherwise.
-*/
-function isPNG(array) {
-  const referenceView = new DataView(new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]).buffer);
-  const arrayBufferView = new DataView(array.buffer, 0, 8);
-  return referenceView.getBigUint64() === arrayBufferView.getBigUint64();
 }
 
 /**


### PR DESCRIPTION
Lately I've got some feedback from users of my package, that a `isPNG` check doesn't work well for all types of PNGs.

I'm still trying to figure out what's the exact scenario that makes `isPNG` from `meta-png` to fails sometimes, but [I've got confirmation](https://github.com/FRSOURCE/cypress-plugin-visual-regression-diff/issues/173#issuecomment-1310162342) that switching it to [the method coming from `is-png` package fixes the issue](https://github.com/sindresorhus/is-png/blob/cc99005ed92aa992598d2a91063901ccd78b1ac6/index.js).

So I think it would be beneficial for the `meta-png` library to do this switch internally (`is-png` is for sure battle-tested library). What do you think @lucach?